### PR TITLE
Fix badge contrast

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -90,4 +90,5 @@ body {
 }
 .placene {
    background: #19647e;
+   color: white;
 }


### PR DESCRIPTION
The contrast of the <kbd>Paid</kbd> badge is pretty bad, so this PR changes the color to white

Before:
![image](https://user-images.githubusercontent.com/29888641/120887075-41672100-c5f1-11eb-9825-52408c2d4bb7.png)

After:
![image](https://user-images.githubusercontent.com/29888641/120887078-44621180-c5f1-11eb-8de1-e14c571d60e2.png)
